### PR TITLE
Make root Query a function in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ import schema from 'schema.gql'
 describe('My Cypress Test', () => {
   beforeEach(() => {
     cy.mockGraphQL(schema, {
-      Query: {
+      Query: () => ({
         people: () => ([
           {
             firstname: 'Gary',
             surname: 'Ryan'
           }
         ])
-      }
+      })
     })
   })
 


### PR DESCRIPTION
This PR updates the README to set the root Query resolver to be a function. If it is a plain object, the graphql-tools mock utility throws an error.

See [issue on dep repo](https://github.com/ardatan/graphql-tools/issues/275#issue-206732411)